### PR TITLE
[Workaround] Use meta-oe-fixups to solve srecord issue

### DIFF
--- a/aos-rcar-gen3.yaml
+++ b/aos-rcar-gen3.yaml
@@ -41,7 +41,7 @@ common_data:
       rev: "e27c46b"
     - type: git
       url: "https://github.com/xen-troops/meta-xt-rcar.git"
-      rev: "3f40999"
+      rev: "5d4e9d1"
     - type: git
       url: "https://github.com/aoscloud/meta-aos.git"
       rev: "v6.0.2"
@@ -211,6 +211,7 @@ components:
         - "../meta-openembedded/meta-filesystems"
         - "../meta-xt-common/meta-xt-domx"
         - "../meta-xt-common/meta-xt-driver-domain"
+        - "../meta-xt-rcar/meta-oe-fixups"
         - "../meta-xt-rcar/meta-xt-rcar-fixups"
         - "../meta-xt-rcar/meta-xt-rcar-driver-domain"
         - "../meta-xt-rcar/meta-xt-rcar-domx"


### PR DESCRIPTION
Note: this commit is cherry-picked from
meta-xt-prod-devel-rcar with all signatures.

---

Add layer with workaround for incorrect libc
used by srec_cat.
See comments inside `meta-oe-fixups` for details.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>
Reviewed-by: Volodymyr Babchuk <volodymyr_babcbuk@epam.com>

---

See https://github.com/xen-troops/meta-xt-rcar/pull/33 for detailed explanation.