### PR TITLE
Integration of the RunX to the build

### DIFF
--- a/aos-rcar-gen3.yaml
+++ b/aos-rcar-gen3.yaml
@@ -47,7 +47,7 @@ common_data:
       rev: "v6.0.2"
     - type: git
       url: "https://github.com/aoscloud/meta-aos-rcar-gen3.git"
-      rev: "v2.0.0"
+      rev: "feature_multinode"
 
   # Common configuration options for all yocto-based domains
   conf: &COMMON_CONF

--- a/meta-aos-rcar-gen3-dom0/conf/layer.conf
+++ b/meta-aos-rcar-gen3-dom0/conf/layer.conf
@@ -7,6 +7,6 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "aos-rcar-gen3-dom0"
 BBFILE_PATTERN_aos-rcar-gen3-dom0 := "^${LAYERDIR}/"
-BBFILE_PRIORITY_aos-rcar-gen3-dom0 = "7"
+BBFILE_PRIORITY_aos-rcar-gen3-dom0 = "12"
 
 LAYERSERIES_COMPAT_aos-rcar-gen3-dom0 = "dunfell"

--- a/meta-aos-rcar-gen3-dom0/recipes-core/core-image-thin-initramfs/core-image-thin-initramfs.bbappend
+++ b/meta-aos-rcar-gen3-dom0/recipes-core/core-image-thin-initramfs/core-image-thin-initramfs.bbappend
@@ -2,6 +2,8 @@
 
 IMAGE_POSTPROCESS_COMMAND += "set_image_version; "
 
+IMAGE_INSTALL_append = " runx"
+
 set_image_version() {
     install -d ${DEPLOY_DIR_IMAGE}/aos
     echo "VERSION=\"${DOM0_IMAGE_VERSION}\"" > ${DEPLOY_DIR_IMAGE}/aos/version

--- a/meta-aos-rcar-gen3-dom0/recipes-core/runx/runx/0001-files-create-Update-create-script-to-start-unikernel.patch
+++ b/meta-aos-rcar-gen3-dom0/recipes-core/runx/runx/0001-files-create-Update-create-script-to-start-unikernel.patch
@@ -1,0 +1,120 @@
+From 37c8fc8f16318cb6a38f971c62c0eb66bdc37a8b Mon Sep 17 00:00:00 2001
+Message-Id: <37c8fc8f16318cb6a38f971c62c0eb66bdc37a8b.1671222770.git.oleksii_moisieiev@epam.com>
+From: Oleksii Moisieiev <oleksii_moisieiev@epam.com>
+Date: Mon, 28 Nov 2022 12:17:23 +0200
+Subject: [PATCH] files/create: Update create script to start unikernels
+
+Updated format of the create script, which allows set set following parameter:
+1) set pvcalls format
+2) set cni configuarion
+3) set memory configuration
+4) set cpu configuration
+
+Signed-off-by: Oleksii Moisieiev <oleksii_moisieiev@epam.com>
+---
+ files/create | 58 +++++++++++++++++++++++++++++++++++++++++-----------
+ 1 file changed, 46 insertions(+), 12 deletions(-)
+
+diff --git a/files/create b/files/create
+index 0dcae76..92021df 100755
+--- a/files/create
++++ b/files/create
+@@ -12,8 +12,14 @@ appname=`cat $configfile | jq '.["Path"]'`
+ cmdline=\"`cat $configfile | jq  -c -r '.["process"]["args"] | join("\" \"")'`\"
+ env=`cat $configfile | jq  -c -r '.["process"]["env"] | join("\" \"")'`
+ xlconf=""
++vcpus=`cat $configfile | jq -c -r '.["linux"]["resources"]["vcpus"]["count"]'`
++memory=`cat $configfile | jq -c -r '.["linux"]["resources"]["memory"]["limit"]'`
++disk=`cat $configfile | jq -c -r '.["disk"]["path"]'`
+ kernel="$workpath/kernel"
+ ramdisk="$workpath/initrd"
++extra_cmd=""
++network_cfg=""
++pvcalls_cfg="backend=0"
+ for i in $env
+ do
+     i=$(echo $i | tr -d \")
+@@ -34,7 +40,20 @@ do
+     if [[ $i = RUNX_RAMDISK=* ]]
+     then
+         ramdisk=${i#RUNX_RAMDISK=}
+-        ramdisk="$mountpoint"/"$ramdisk"
++        [ -z $ramdisk ] ||
++            ramdisk="$mountpoint"/"$ramdisk"
++    fi
++    if [[ $i = EXTRA=* ]]
++    then
++        extra_cmd="${extra_cmd} ${i#EXTRA=}"
++    fi
++    if [[ $i = NETWORK_CFG=* ]]
++    then
++        network_cfg="${i#NETWORK_CFG=}, "
++    fi
++    if [[ $i = PVCALLS_CFG=* ]]
++    then
++       pvcalls_cfg="${i#PVCALLS_CFG=}"
+     fi
+ done
+ 
+@@ -46,6 +65,7 @@ then
+     netfile=`echo "$netconf" | awk -F "," '{print $1}'`
+     netname=`echo "$netconf" | awk -F "," '{print $2}'`
+     netaddr=`echo "$netconf" | awk -F "," '{print $3}'`
++    netmask=`echo "$netconf" | awk -F "," '{print $4}'`
+     nettype=`cat $netfile | jq -c -r "select(.[\"name\"] == \"$netname\") | .[\"type\"]"`
+ 
+     if test "$nettype" = "bridge"
+@@ -70,25 +90,39 @@ if test "$ramdisk"
+ then
+     echo "ramdisk='$ramdisk'" >> $outconfig
+ fi
+-echo "memory = 1024" >> $outconfig
+-echo "vcpus = 2" >> $outconfig
++echo "memory = $memory" >> $outconfig
++echo "vcpus = $vcpus" >> $outconfig
+ echo "serial='pty'" >> $outconfig
+ echo "boot='c'" >> $outconfig
+ if test $pvcalls -eq 0
+ then
+-    echo "vif=['bridge="$bridge"']" >> $outconfig
+-    if test "$netaddr"
+-    then
+-        echo extra=\'console=hvc0 root=9p rdinit=/bin/init ip=$netaddr gw=$gw route=$route\' >> $outconfig
++    ipconfig=""
++    if test "$netaddr"; then
++        ipconfig="$netaddr"
++        if test "$netmask"; then
++        ipconfig="$ipconfig $netmask"
++        fi
++        if test "gw"; then
++            ipconfig="$ipconfig $gw"
++        fi
++
++        echo "vif=['${network_cfg}bridge=${bridge}, ip=${ipconfig}']" >> $outconfig
++        echo extra=\'console=hvc0 ip=$netaddr gw=$gw route=${route}${extra_cmd}\' >> $outconfig
+     else
+-        echo extra=\'console=hvc0 root=9p rdinit=/bin/init ip=dhcp\' >> $outconfig
++        echo "vif=['${network_cfg}bridge=${bridge}, ip=dhcp']" >> $outconfig
++        echo extra=\'console=hvc0 ip=dhcp${extra_cmd}\' >> $outconfig
+     fi
+ else
+-    echo "pvcalls=['']" >> $outconfig
+-    echo extra=\'console=hvc0 root=9p rdinit=/bin/init pvcalls=1\' >> $outconfig
++    echo "pvcalls=['${pvcalls_cfg}']" >> $outconfig
++    echo extra=\'console=hvc0 pvcalls=1${extra_cmd}\' >> $outconfig
++fi
++if test "$disk"; then
++    if [[ $disk != null ]]; then
++        echo "disk= [ 'format=raw, vdev=xvda, access=rw, target=$disk' ]" >> $outconfig
++    fi
+ fi
+-echo "vfb=['vnc=1']" >> $outconfig
+-echo "p9=[ 'tag=share_dir,security_model=none,path=$mountpoint' ]" >> $outconfig
++#echo "vfb=['vnc=1']" >> $outconfig
++#echo "p9=[ 'tag=share_dir,security_model=none,path=$mountpoint' ]" >> $outconfig
+ echo "name=\"$containerid\"" >> $outconfig
+ if test -f "$xlconf"
+ then
+-- 
+2.25.1
+

--- a/meta-aos-rcar-gen3-dom0/recipes-core/runx/runx_git.bbappend
+++ b/meta-aos-rcar-gen3-dom0/recipes-core/runx/runx_git.bbappend
@@ -1,0 +1,49 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRCREV_runx = "0c7edb3453398d7a0c594ce026c9c1e93c2541cc"
+
+SRC_URI = " \
+    git://github.com/lf-edge/runx;nobranch=1;name=runx \
+    file://0001-files-create-Update-create-script-to-start-unikernel.patch \
+"
+
+SRC_URI[md5sum] = "ce9b2d974d27408a61c53a30d3f98fb9"
+SRC_URI[sha256sum] = "bf338980b1670bca287f9994b7441c2361907635879169c64ae78364efc5f491"
+
+PV = "v1.1-git${SRCREV_runx}"
+
+REQUIRED_DISTRO_FEATURES_remove = "vmsep"
+
+DEPENDS_remove = "busybox go-build openssl-native coreutils-native util-linux-native"
+DEPENDS_remove = "xz-native bc-native qemu-native"
+
+RDEPENDS_${PN}_remove = "go-build"
+
+RUNX_USE_INTERNAL_BUSYBOX ?= ""
+
+do_compile() {
+    export CC="${CC}"
+    export LD="${LD}"
+    export CFLAGS="${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS} ${CFLAGS}"
+    export LDFLAGS="${TOOLCHAIN_OPTIONS} ${HOST_LD_ARCH} ${LDFLAGS}"
+    export HOSTCFLAGS="${BUILD_CFLAGS} ${BUILD_LDFLAGS}"
+    export CROSS_COMPILE="${TARGET_PREFIX}"
+    export ARCH="%{TARGET_PREFIX}"
+    cd ${S}/sendfd
+    make
+}
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 755 ${S}/runX ${D}${bindir}
+
+    install -d ${D}${datadir}/runX
+    install -m 755 ${S}/files/start ${D}/${datadir}/runX
+    install -m 755 ${S}/files/create ${D}/${datadir}/runX
+    install -m 755 ${S}/files/state ${D}/${datadir}/runX
+    install -m 755 ${S}/files/delete ${D}/${datadir}/runX
+    install -m 755 ${S}/files/pause ${D}/${datadir}/runX
+    install -m 755 ${S}/files/mount ${D}/${datadir}/runX
+    install -m 755 ${S}/files/serial_start ${D}/${datadir}/runX
+    install -m 755 ${S}/sendfd/sendfd ${D}/${datadir}/runX
+}

--- a/meta-aos-rcar-gen3-domd/conf/layer.conf
+++ b/meta-aos-rcar-gen3-domd/conf/layer.conf
@@ -7,6 +7,6 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "aos-rcar-gen3-domd"
 BBFILE_PATTERN_aos-rcar-gen3-domd := "^${LAYERDIR}/"
-BBFILE_PRIORITY_aos-rcar-gen3-domd = "7"
+BBFILE_PRIORITY_aos-rcar-gen3-domd = "12"
 
 LAYERSERIES_COMPAT_aos-rcar-gen3-domd = "dunfell"

--- a/meta-aos-rcar-gen3-domf/conf/layer.conf
+++ b/meta-aos-rcar-gen3-domf/conf/layer.conf
@@ -7,6 +7,6 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "aos-rcar-gen3-domf"
 BBFILE_PATTERN_aos-rcar-gen3-domf := "^${LAYERDIR}/"
-BBFILE_PRIORITY_aos-rcar-gen3-domf = "7"
+BBFILE_PRIORITY_aos-rcar-gen3-domf = "12"
 
 LAYERSERIES_COMPAT_aos-rcar-gen3-domf = "dunfell"

--- a/meta-aos-rcar-gen3-domx/conf/layer.conf
+++ b/meta-aos-rcar-gen3-domx/conf/layer.conf
@@ -7,6 +7,6 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "aos-rcar-gen3-domx"
 BBFILE_PATTERN_aos-rcar-gen3-domx := "^${LAYERDIR}/"
-BBFILE_PRIORITY_aos-rcar-gen3-domx = "7"
+BBFILE_PRIORITY_aos-rcar-gen3-domx = "12"
 
 LAYERSERIES_COMPAT_aos-rcar-gen3-domx = "dunfell"


### PR DESCRIPTION
Integration runX untility. It hase compatible to containerd interface and can replace runc.
It is inteded to be used to start unikernels as domains.