### PR TITLE
Introduce support of cockpit build

### DIFF
--- a/aos-rcar-gen3.yaml
+++ b/aos-rcar-gen3.yaml
@@ -24,6 +24,12 @@ variables:
   AOS_BUNDLE_DOMD_TYPE: "full"
   AOS_BUNDLE_DOMF_TYPE: "full"
 
+  # Update modules
+  AOS_UM_UPDATE_MODULES: "updatemodules/overlaysystemd"
+
+  #Service configuration
+  AOS_DOMF_UM_CONFIG: "aos_updatemanager.cfg"
+
 common_data:
   # Sources used by all yocto-based domains
   sources: &COMMON_SOURCES
@@ -254,6 +260,9 @@ components:
         # Aos configuration
         - [AOS_RUNNER, "crun"]
         - [DOMF_IMAGE_VERSION, "%{AOS_DOMF_IMAGE_VERSION}"]
+
+        #Aos update manager configuration
+        - [AOS_DOMF_UM_CONFIG, "%{AOS_DOMF_UM_CONFIG}"]
 
       layers:
         - "../meta-openembedded/meta-filesystems"
@@ -495,3 +504,31 @@ parameters:
       overrides:
         variables:
           AOS_VIS_DATA_PROVIDER: "telemetryemulatoradapter"
+
+  #Enable sshmodule update
+  ENABLE_SSH_UPDATE:
+    desc: "Add ssh update module to domf"
+    "no":
+      default: true
+    "yes":
+      overrides:
+        components:
+          domf:
+            builder:
+              conf:
+                - [AOS_UM_UPDATE_MODULES_appemd, " updatemodules/sshmodule"]
+
+  # Build to manage cockpit
+  SUPPORT_COCKPIT:
+    desc: "Build teh configuration for cockpit demo."  
+    "no":
+      default: true
+    "yes":
+      overrides:
+        components:
+          domf:
+            builder:
+              conf:
+                - [AOS_DOMF_UM_CONFIG, "aos_cockpit_updatemanager.cfg"]
+                - [OVERRIDES_append, ":cockpit"]
+

--- a/doc/cockpit_boardconfig.json
+++ b/doc/cockpit_boardconfig.json
@@ -1,0 +1,17 @@
+{
+    "components": [
+        {
+            "id": "h3ulcb-4x2g-ab-1.0-dom0"
+        },
+        {
+            "id": "h3ulcb-4x2g-ab-1.0-domd"
+        },
+        {
+            "id": "h3ulcb-4x2g-ab-1.0-domf"
+        },
+	{
+	     "id": "h3ulcb-4x2g-ab-1.0-cluster"
+	}
+    ],
+    "formatVersion": 1
+}

--- a/meta-aos-rcar-gen3-domf/recipes-aos/aos-updatemanager/aos-updatemanager_git.bbappend
+++ b/meta-aos-rcar-gen3-domf/recipes-aos/aos-updatemanager/aos-updatemanager_git.bbappend
@@ -1,13 +1,9 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI_append = "\
-    file://aos_updatemanager.cfg \
+    file://${AOS_DOMF_UM_CONFIG} \
     file://aos-updatemanager.service \
     file://aos-reboot.service \
-"
-
-AOS_UM_UPDATE_MODULES ?= "\
-    updatemodules/overlaysystemd \
 "
 
 inherit systemd
@@ -43,7 +39,7 @@ python do_update_componet_ids() {
 
 do_install_append() {
     install -d ${D}${sysconfdir}/aos
-    install -m 0644 ${WORKDIR}/aos_updatemanager.cfg ${D}${sysconfdir}/aos
+    install -m 0644 ${WORKDIR}/${AOS_DOMF_UM_CONFIG} ${D}${sysconfdir}/aos/aos_updatemanager.cfg
 
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/aos-updatemanager.service ${D}${systemd_system_unitdir}/aos-updatemanager.service
@@ -55,5 +51,13 @@ do_install_append() {
         install -m 0644 ${S}/${source_migration_path}/* ${D}${MIGRATION_SCRIPTS_PATH}
     fi
 }
+
+pkg_postinst_${PN}() {
+    # Add cockpit to /etc/hosts
+    if ! grep -q 'cockpit' $D${sysconfdir}/hosts ; then
+        echo '192.168.5.85     cockpit' >> $D${sysconfdir}/hosts
+    fi
+}
+
 
 addtask update_componet_ids after do_install before do_package

--- a/meta-aos-rcar-gen3-domf/recipes-aos/aos-updatemanager/files/aos_cockpit_updatemanager.cfg
+++ b/meta-aos-rcar-gen3-domf/recipes-aos/aos-updatemanager/files/aos_cockpit_updatemanager.cfg
@@ -1,0 +1,47 @@
+{
+    "ID": "um_domf",
+    "ServerUrl": "aoscm:8091",
+    "IamServerUrl": "aosiam:8090",
+    "CACert": "/etc/ssl/certs/Aos_Root_CA.pem",
+    "CertStorage": "um",
+    "WorkingDir": "/var/aos/workdirs/um",
+    "UpdateModules": [
+        {
+            "ID": "domf",
+            "Disabled": false,
+            "UpdatePriority": 0,
+            "RebootPriority": 0,
+            "Plugin": "overlaysystemd",
+            "Params": {
+                "VersionFile": "/etc/aos/version",
+                "UpdateDir": "/var/aos/downloads/update_rootfs",
+                "SystemdChecker": {
+                    "SystemServices": [
+                        "aos-iamanager.service",
+                        "aos-communicationmanager.service",
+                        "aos-servicemanager.service"
+                    ]
+                }
+            }
+        },
+	{
+            "ID": "cluster",
+            "Disabled": false,
+            "UpdatePriority": 0,
+            "RebootPriority": 0,
+            "Plugin": "sshmodule",
+            "Params": {
+	        "Host":"cockpit:22",
+		"User":"root",
+		"DestPath":"/tmp/update-mode.tar.bz2",
+		"Commands":[
+		        "cd /tmp/ && tar xf ./update-mode.tar.bz2 && ./update-cluster.sh"
+	  	]
+            }
+        }
+    ],
+    "migration": {
+        "migrationPath" : "/usr/share/aos/um/migration",
+        "mergedMigrationPath" : "/var/aos/workdirs/um/migration"
+    }
+}

--- a/meta-aos-rcar-gen3-domf/recipes-core/images/core-image-minimal.bbappend
+++ b/meta-aos-rcar-gen3-domf/recipes-core/images/core-image-minimal.bbappend
@@ -19,6 +19,18 @@ IMAGE_INSTALL_append = " \
     aos-updatemanager \
 "
 
+#telemetry related components
+IMAGE_INSTALL_cockpit_append = " \
+    python3-compression \
+    python3-crypt \
+    python3-json \
+    python3-misc \
+    python3-shell \
+    python3-six \
+    python3-threading \
+    python3-websocket-client \
+"
+
 # Aos related tasks
 
 ROOTFS_POSTPROCESS_COMMAND += "set_rootfs_version; "


### PR DESCRIPTION
 DomF: Introduce support of cockpit build

aos-rcar-gen3.yaml
-Add support the dedicated config files for update manager of domf.
The variable AOS_DOMF_UM_CONFIG is intriduced to change the configuration file.
By default, value is 'aos_updatemanager.cfg', but if parameter SUPPORT_COCKPIT is yes,
the variable is changed to aos_cockpit_updatemanager.cfg to satisfy the requirements of
the product meta-xt-prod-cockpit-rcar.

-Parameter SUPPORT_COCKPIT, allows enable build for cockpit.
Default parameter is 'no'. If parameters is yes, the value of AOS_DOMF_UM_CONFIG is
changed at 'aos_cockpit_updatemanager.cfg'

-Parameter ENABLE_SSH_UPDATE allows to add sshmodule for update via ssh protocol.
Default value is 'no'.

aos-updatemanager_git
-Support of AOS_DOMF_UM_CONFIG.
-Add cockpit name in the etc/hosts

doc/cockpit_boardconfig.json
-aos_updatemanager configuration file to support cockpit. Use this file
to configure the cloud.

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>