### PR TITLE
Set the priority of layers to 12

### DIFF
--- a/meta-aos-rcar-gen3-dom0/conf/layer.conf
+++ b/meta-aos-rcar-gen3-dom0/conf/layer.conf
@@ -7,6 +7,6 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "aos-rcar-gen3-dom0"
 BBFILE_PATTERN_aos-rcar-gen3-dom0 := "^${LAYERDIR}/"
-BBFILE_PRIORITY_aos-rcar-gen3-dom0 = "7"
+BBFILE_PRIORITY_aos-rcar-gen3-dom0 = "12"
 
 LAYERSERIES_COMPAT_aos-rcar-gen3-dom0 = "dunfell"

--- a/meta-aos-rcar-gen3-domd/conf/layer.conf
+++ b/meta-aos-rcar-gen3-domd/conf/layer.conf
@@ -7,6 +7,6 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "aos-rcar-gen3-domd"
 BBFILE_PATTERN_aos-rcar-gen3-domd := "^${LAYERDIR}/"
-BBFILE_PRIORITY_aos-rcar-gen3-domd = "7"
+BBFILE_PRIORITY_aos-rcar-gen3-domd = "12"
 
 LAYERSERIES_COMPAT_aos-rcar-gen3-domd = "dunfell"

--- a/meta-aos-rcar-gen3-domf/conf/layer.conf
+++ b/meta-aos-rcar-gen3-domf/conf/layer.conf
@@ -7,6 +7,6 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "aos-rcar-gen3-domf"
 BBFILE_PATTERN_aos-rcar-gen3-domf := "^${LAYERDIR}/"
-BBFILE_PRIORITY_aos-rcar-gen3-domf = "7"
+BBFILE_PRIORITY_aos-rcar-gen3-domf = "12"
 
 LAYERSERIES_COMPAT_aos-rcar-gen3-domf = "dunfell"

--- a/meta-aos-rcar-gen3-domx/conf/layer.conf
+++ b/meta-aos-rcar-gen3-domx/conf/layer.conf
@@ -7,6 +7,6 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "aos-rcar-gen3-domx"
 BBFILE_PATTERN_aos-rcar-gen3-domx := "^${LAYERDIR}/"
-BBFILE_PRIORITY_aos-rcar-gen3-domx = "7"
+BBFILE_PRIORITY_aos-rcar-gen3-domx = "12"
 
 LAYERSERIES_COMPAT_aos-rcar-gen3-domx = "dunfell"


### PR DESCRIPTION
To make sure that specific components can override/redefine settings from more generic levels, we set the following priorities for levels:

```
meta-xt-common     -  8
meta-xt-<platform> - 10
meta-<product>     - 12
```