### PR TITLE
[iam] Increase max items to 2 for Aos services certs

### DIFF
--- a/meta-aos-rcar-gen3-domd/recipes-aos/aos-iamanager/files/main-node/aos_iamanager.cfg
+++ b/meta-aos-rcar-gen3-domd/recipes-aos/aos-iamanager/files/main-node/aos_iamanager.cfg
@@ -23,7 +23,7 @@
             "ID": "online",
             "Plugin": "pkcs11module",
             "Algorithm": "ecc",
-            "MaxItems": 1,
+            "MaxItems": 2,
             "Params": {
                 "Library": "/usr/lib/libckteec.so.0.1",
                 "TokenLabel": "aoscloud",
@@ -45,7 +45,7 @@
             "ID": "iam",
             "Plugin": "pkcs11module",
             "Algorithm": "ecc",
-            "MaxItems": 1,
+            "MaxItems": 2,
             "ExtendedKeyUsage": [
                 "serverAuth",
                 "clientAuth"
@@ -60,7 +60,7 @@
             "ID": "sm",
             "Plugin": "pkcs11module",
             "Algorithm": "ecc",
-            "MaxItems": 1,
+            "MaxItems": 2,
             "ExtendedKeyUsage": [
                 "serverAuth",
                 "clientAuth"
@@ -75,7 +75,7 @@
             "ID": "um",
             "Plugin": "pkcs11module",
             "Algorithm": "ecc",
-            "MaxItems": 1,
+            "MaxItems": 2,
             "ExtendedKeyUsage": [
                 "clientAuth"
             ],
@@ -89,7 +89,7 @@
             "ID": "cm",
             "Plugin": "pkcs11module",
             "Algorithm": "ecc",
-            "MaxItems": 1,
+            "MaxItems": 2,
             "ExtendedKeyUsage": [
                 "serverAuth",
                 "clientAuth"

--- a/meta-aos-rcar-gen3-domd/recipes-aos/aos-iamanager/files/secondary-node/aos_iamanager.cfg
+++ b/meta-aos-rcar-gen3-domd/recipes-aos/aos-iamanager/files/secondary-node/aos_iamanager.cfg
@@ -17,7 +17,7 @@
             "ID": "iam",
             "Plugin": "pkcs11module",
             "Algorithm": "ecc",
-            "MaxItems": 1,
+            "MaxItems": 2,
             "ExtendedKeyUsage": [
                 "serverAuth"
             ],
@@ -31,7 +31,7 @@
             "ID": "sm",
             "Plugin": "pkcs11module",
             "Algorithm": "ecc",
-            "MaxItems": 1,
+            "MaxItems": 2,
             "ExtendedKeyUsage": [
                 "serverAuth",
                 "clientAuth"
@@ -46,7 +46,7 @@
             "ID": "um",
             "Plugin": "pkcs11module",
             "Algorithm": "ecc",
-            "MaxItems": 1,
+            "MaxItems": 2,
             "ExtendedKeyUsage": [
                 "clientAuth"
             ],

--- a/meta-aos-rcar-gen3-domx/recipes-aos/aos-iamanager/files/aos_iamanager.cfg
+++ b/meta-aos-rcar-gen3-domx/recipes-aos/aos-iamanager/files/aos_iamanager.cfg
@@ -17,7 +17,7 @@
             "ID": "iam",
             "Plugin": "pkcs11module",
             "Algorithm": "ecc",
-            "MaxItems": 1,
+            "MaxItems": 2,
             "ExtendedKeyUsage": [
                 "serverAuth"
             ],
@@ -31,7 +31,7 @@
             "ID": "sm",
             "Plugin": "pkcs11module",
             "Algorithm": "ecc",
-            "MaxItems": 1,
+            "MaxItems": 2,
             "ExtendedKeyUsage": [
                 "clientAuth"
             ],
@@ -45,7 +45,7 @@
             "ID": "um",
             "Plugin": "pkcs11module",
             "Algorithm": "ecc",
-            "MaxItems": 1,
+            "MaxItems": 2,
             "ExtendedKeyUsage": [
                 "clientAuth"
             ],


### PR DESCRIPTION
We can't renew certificates that are currently in use. In order to support certificates renewing, we need to have at least two items in cert storage.